### PR TITLE
feat(cross-subname-indexing): allow activating multiple plugins together

### DIFF
--- a/.env.local.example
+++ b/.env.local.example
@@ -7,7 +7,7 @@ RPC_URL_59144=https://linea-rpc.publicnode.com
 
 # Identify which indexer plugin to activate (see `src/plugins` for available plugins)
 
-ACTIVE_PLUGIN=base.eth
+ACTIVE_PLUGINS=base.eth
 
 # Database configuration
 

--- a/.env.local.example
+++ b/.env.local.example
@@ -7,13 +7,25 @@ RPC_URL_59144=https://linea-rpc.publicnode.com
 
 # Identify which indexer plugin to activate (see `src/plugins` for available plugins)
 
-ACTIVE_PLUGINS=base.eth
+# ACTIVE_PLUGINS=eth,base.eth,linea.eth
+# ACTIVE_PLUGINS=base.eth,linea.eth
+ACTIVE_PLUGINS=eth
 
 # Database configuration
 
-# This is where the indexer will create the tables defined in ponder.schema.ts
-# No two indexer instances can use the same database schema at the same time. This prevents data corruption.
-# @link https://ponder.sh/docs/api-reference/database#database-schema-rules
-DATABASE_SCHEMA=subname_index_base.eth
-# The indexer will use Postgres with that as the connection string. If not defined, the indexer will use PSlite.
+# This is a namespace for the tables that the indexer will create to store indexed data.
+# It should be a string that is unique to the running indexer instance.
+#
+# Keeping the database schema unique to the indexer instance is important to
+# 1) speed up indexing after a restart
+# 2) prevent data corruption
+#
+# No two indexer instances can use the same database schema at the same time.
+#
+# Read more about database schema rules here:
+# https://ponder.sh/docs/api-reference/database#database-schema-rules
+DATABASE_SCHEMA=ens
+
+# This is the connection string for the database that the indexer will use to store data.
+# It should be in the format of `postgresql://<username>:<password>@<host>:<port>/<database>`
 DATABASE_URL=postgresql://dbuser:abcd1234@localhost:5432/my_database

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
   "dependencies": {
     "@ensdomains/ensjs": "^4.0.2",
     "hono": "^4.6.14",
-    "ponder": "^0.8.17",
+    "ponder": "^0.8.24",
     "viem": "^2.21.57"
   },
   "devDependencies": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -18,8 +18,8 @@ importers:
         specifier: ^4.6.14
         version: 4.6.14
       ponder:
-        specifier: ^0.8.17
-        version: 0.8.17(@opentelemetry/api@1.9.0)(@types/node@20.17.10)(@types/pg@8.11.10)(hono@4.6.14)(typescript@5.7.2)(viem@2.21.57(typescript@5.7.2))
+        specifier: ^0.8.24
+        version: 0.8.24(@opentelemetry/api@1.9.0)(@types/node@20.17.10)(@types/pg@8.11.10)(hono@4.6.14)(typescript@5.7.2)(viem@2.21.57(typescript@5.7.2))
       viem:
         specifier: ^2.21.57
         version: 2.21.57(typescript@5.7.2)
@@ -1452,8 +1452,8 @@ packages:
     resolution: {integrity: sha512-ip4qdzjkAyDDZklUaZkcRFb2iA118H9SgRh8yzTkSQK8HilsOJF7rSY8HoW5+I0M46AZgX/pxbprf2vvzQCE0Q==}
     hasBin: true
 
-  ponder@0.8.17:
-    resolution: {integrity: sha512-p0gvs0CJpdJ6sf5OOQYXaIfmIeUVoTMkCbPVAJ1jK1O2m62ZnTlxpnGrPp5ZAWYxdlCSQQCpZpNhdsYGejGK+g==}
+  ponder@0.8.24:
+    resolution: {integrity: sha512-WMj9FmlY+A2Wb07rHbhekai9Z/JsCFz31+7+Zfjg5I933LbV3FeWYy/q277A4h7ai9o/yrVBfkL8kbUmO40Y7g==}
     engines: {node: '>=18.14'}
     hasBin: true
     peerDependencies:
@@ -3157,7 +3157,7 @@ snapshots:
       sonic-boom: 3.8.1
       thread-stream: 2.7.0
 
-  ponder@0.8.17(@opentelemetry/api@1.9.0)(@types/node@20.17.10)(@types/pg@8.11.10)(hono@4.6.14)(typescript@5.7.2)(viem@2.21.57(typescript@5.7.2)):
+  ponder@0.8.24(@opentelemetry/api@1.9.0)(@types/node@20.17.10)(@types/pg@8.11.10)(hono@4.6.14)(typescript@5.7.2)(viem@2.21.57(typescript@5.7.2)):
     dependencies:
       '@babel/code-frame': 7.26.2
       '@commander-js/extra-typings': 12.1.0(commander@12.1.0)

--- a/ponder.config.ts
+++ b/ponder.config.ts
@@ -4,13 +4,10 @@ import * as baseEthPlugin from "./src/plugins/base.eth/ponder.config";
 import * as ethPlugin from "./src/plugins/eth/ponder.config";
 import * as lineaEthPlugin from "./src/plugins/linea.eth/ponder.config";
 
+/** list of all available plugins — any of them can be activated in the runtime */
 const plugins = [baseEthPlugin, ethPlugin, lineaEthPlugin] as const;
 
-// The type of the exported default is the intersection of all plugin configs to
-// each plugin can be correctly typechecked
 type AllPluginsConfig = IntersectionOf<(typeof plugins)[number]["config"]>;
-
-export default loadActivePlugins();
 
 /**
  * Activates the indexing handlers included in selected active plugins and returns their combined config.
@@ -26,3 +23,7 @@ function loadActivePlugins(): AllPluginsConfig {
 
   return config as AllPluginsConfig;
 }
+
+// The type of the defuexporte is the intersection of all plugin configs to
+// each plugin can be correctly typechecked
+export default loadActivePlugins();

--- a/ponder.config.ts
+++ b/ponder.config.ts
@@ -4,17 +4,20 @@ import * as baseEthPlugin from "./src/plugins/base.eth/ponder.config";
 import * as ethPlugin from "./src/plugins/eth/ponder.config";
 import * as lineaEthPlugin from "./src/plugins/linea.eth/ponder.config";
 
-/** list of all available plugins — any of them can be activated in the runtime */
+// list of all available plugins
+// any of them can be activated in the runtime
 const plugins = [baseEthPlugin, ethPlugin, lineaEthPlugin] as const;
 
+// intersection of all available plugin configs to support correct typechecking
+// of the indexing handlers
 type AllPluginsConfig = IntersectionOf<(typeof plugins)[number]["config"]>;
 
-/**
- * Activates the indexing handlers included in selected active plugins and returns their combined config.
- */
-function loadActivePlugins(): AllPluginsConfig {
+// Activates the indexing handlers included in selected active plugins and
+// returns and intersection of their combined config.
+function getActivePluginsConfig(): AllPluginsConfig {
   const activePlugins = getActivePlugins(plugins);
 
+  // load indexing handlers from the active plugins into the runtime
   activePlugins.forEach((plugin) => plugin.activate());
 
   const config = activePlugins
@@ -24,6 +27,6 @@ function loadActivePlugins(): AllPluginsConfig {
   return config as AllPluginsConfig;
 }
 
-// The type of the defuexporte is the intersection of all plugin configs to
-// each plugin can be correctly typechecked
-export default loadActivePlugins();
+// The type of the default export is the intersection of all available plugin
+// configs to each plugin can be correctly typechecked
+export default getActivePluginsConfig();

--- a/ponder.config.ts
+++ b/ponder.config.ts
@@ -1,29 +1,39 @@
-import { ACTIVE_PLUGIN } from "./src/lib/plugin-helpers";
+import { createConfig } from "ponder";
+import { deepMergeRecursive } from "./src/lib/helpers";
+import { type IntersectionOf, getActivePlugins } from "./src/lib/plugin-helpers";
 import * as baseEthPlugin from "./src/plugins/base.eth/ponder.config";
 import * as ethPlugin from "./src/plugins/eth/ponder.config";
 import * as lineaEthPlugin from "./src/plugins/linea.eth/ponder.config";
 
 const plugins = [baseEthPlugin, ethPlugin, lineaEthPlugin] as const;
 
-// here we export only a single 'plugin's config, by type it as every config
-// this makes all of the mapping types happy at typecheck-time, but only the
-// relevant config is run at runtime
-export default ((): AllConfigs => {
-  const pluginToActivate = plugins.find((p) => p.ownedName === ACTIVE_PLUGIN);
-
-  if (!pluginToActivate) {
-    throw new Error(`Unsupported ACTIVE_PLUGIN: ${ACTIVE_PLUGIN}`);
-  }
-
-  pluginToActivate.activate();
-
-  return pluginToActivate.config as AllConfigs;
-})();
-
-// Helper type to get the intersection of all config types
-type IntersectionOf<T> = (T extends any ? (x: T) => void : never) extends (x: infer R) => void
-  ? R
-  : never;
 // The type of the exported default is the intersection of all plugin configs to
 // each plugin can be correctly typechecked
-type AllConfigs = IntersectionOf<(typeof plugins)[number]["config"]>;
+type AllPluginsConfig = IntersectionOf<(typeof plugins)[number]["config"]>;
+
+const activePlugins = loadActivePlugins();
+
+export default (() =>
+  createConfig({
+    contracts: {
+      ...activePlugins.contracts,
+    },
+    networks: {
+      ...activePlugins.networks,
+    },
+  }) as AllPluginsConfig)();
+
+/**
+ * Activates the indexing handlers included in selected active plugins and returns their combined config.
+ */
+function loadActivePlugins() {
+  const activePlugins = getActivePlugins(plugins);
+
+  activePlugins.forEach((plugin) => plugin.activate());
+
+  const config = activePlugins
+    .map((plugin) => plugin.config)
+    .reduce((acc, val) => deepMergeRecursive(acc, val), {} as AllPluginsConfig);
+
+  return config;
+}

--- a/ponder.config.ts
+++ b/ponder.config.ts
@@ -1,4 +1,3 @@
-import { createConfig } from "ponder";
 import { deepMergeRecursive } from "./src/lib/helpers";
 import { type IntersectionOf, getActivePlugins } from "./src/lib/plugin-helpers";
 import * as baseEthPlugin from "./src/plugins/base.eth/ponder.config";
@@ -11,22 +10,12 @@ const plugins = [baseEthPlugin, ethPlugin, lineaEthPlugin] as const;
 // each plugin can be correctly typechecked
 type AllPluginsConfig = IntersectionOf<(typeof plugins)[number]["config"]>;
 
-const activePlugins = loadActivePlugins();
-
-export default (() =>
-  createConfig({
-    contracts: {
-      ...activePlugins.contracts,
-    },
-    networks: {
-      ...activePlugins.networks,
-    },
-  }) as AllPluginsConfig)();
+export default loadActivePlugins();
 
 /**
  * Activates the indexing handlers included in selected active plugins and returns their combined config.
  */
-function loadActivePlugins() {
+function loadActivePlugins(): AllPluginsConfig {
   const activePlugins = getActivePlugins(plugins);
 
   activePlugins.forEach((plugin) => plugin.activate());
@@ -35,5 +24,5 @@ function loadActivePlugins() {
     .map((plugin) => plugin.config)
     .reduce((acc, val) => deepMergeRecursive(acc, val), {} as AllPluginsConfig);
 
-  return config;
+  return config as AllPluginsConfig;
 }

--- a/src/handlers/Registrar.ts
+++ b/src/handlers/Registrar.ts
@@ -23,7 +23,7 @@ export const makeRegistrarHandlers = (ownedName: `${string}eth`) => {
     if (domain.labelName !== name) {
       await context.db
         .update(domains, { id: node })
-        .set({ labelName: name, name: `${name}${ownedName}` });
+        .set({ labelName: name, name: `${name}.${ownedName}` });
     }
 
     await context.db.update(registrations, { id: label }).set({ labelName: name, cost });

--- a/src/handlers/Registrar.ts
+++ b/src/handlers/Registrar.ts
@@ -79,7 +79,7 @@ export const makeRegistrarHandlers = (ownedName: `${string}eth`) => {
       context: Context;
       args: { name: string; label: Hex; cost: bigint };
     }) {
-      return await setNamePreimage(context, name, label, cost);
+      await setNamePreimage(context, name, label, cost);
     },
 
     async handleNameRenewedByController({
@@ -89,7 +89,7 @@ export const makeRegistrarHandlers = (ownedName: `${string}eth`) => {
       context: Context;
       args: { name: string; label: Hex; cost: bigint };
     }) {
-      return await setNamePreimage(context, name, label, cost);
+      await setNamePreimage(context, name, label, cost);
     },
 
     async handleNameRenewed({
@@ -117,7 +117,7 @@ export const makeRegistrarHandlers = (ownedName: `${string}eth`) => {
 
     async handleNameTransferred({
       context,
-      args: { tokenId, from, to },
+      args: { tokenId, to },
     }: {
       context: Context;
       args: {

--- a/src/handlers/Registry.ts
+++ b/src/handlers/Registry.ts
@@ -15,12 +15,15 @@ export async function setupRootNode({ context }: { context: Context }) {
   await upsertAccount(context, zeroAddress);
 
   // initialize the ENS root to be owned by the zeroAddress and not migrated
-  await context.db.insert(domains).values({
-    id: ROOT_NODE,
-    ownerId: zeroAddress,
-    createdAt: 0n,
-    isMigrated: false,
-  });
+  await context.db
+    .insert(domains)
+    .values({
+      id: ROOT_NODE,
+      ownerId: zeroAddress,
+      createdAt: 0n,
+      isMigrated: false,
+    })
+    .onConflictDoNothing();
 }
 
 function isDomainEmpty(domain: typeof domains.$inferSelect) {

--- a/src/lib/helpers.ts
+++ b/src/lib/helpers.ts
@@ -16,3 +16,55 @@ export const blockConfig = (
   startBlock: Math.min(Math.max(start || 0, startBlock), end || Number.MAX_SAFE_INTEGER),
   endBlock: end,
 });
+
+type AnyObject = { [key: string]: any };
+
+/**
+ * Deep merge two objects recursively.
+ * @param target The target object to merge into.
+ * @param source The source object to merge from.
+ * @returns The merged object.
+ * @see https://stackoverflow.com/a/48218209
+ * @example
+ * const obj1 = { a: 1, b: 2, c: { d: 3 } };
+ * const obj2 = { a: 4, c: { e: 5 } };
+ * const obj3 = deepMergeRecursive(obj1, obj2);
+ * // { a: 4, b: 2, c: { d: 3, e: 5 } }
+ */
+export function deepMergeRecursive<T extends AnyObject, U extends AnyObject>(
+  target: T,
+  source: U,
+): T & U {
+  const output = { ...target } as T & U;
+
+  function isObject(item: any): item is AnyObject {
+    return item && typeof item === "object" && !Array.isArray(item);
+  }
+
+  if (isObject(target) && isObject(source)) {
+    Object.keys(source).forEach((key) => {
+      if (isObject(source[key])) {
+        if (!(key in target)) {
+          Object.assign(output, { [key]: source[key] });
+        } else {
+          (output as AnyObject)[key] = deepMergeRecursive(
+            (target as AnyObject)[key],
+            (source as AnyObject)[key],
+          );
+        }
+      } else if (Array.isArray(source[key])) {
+        if (!(key in target)) {
+          Object.assign(output, { [key]: source[key] });
+        } else {
+          (output as AnyObject)[key] = Array.isArray((target as AnyObject)[key])
+            ? [...(target as AnyObject)[key], ...source[key]]
+            : source[key];
+        }
+      } else {
+        Object.assign(output, { [key]: source[key] });
+      }
+    });
+  }
+
+  return output;
+}

--- a/src/lib/plugin-helpers.ts
+++ b/src/lib/plugin-helpers.ts
@@ -100,8 +100,21 @@ export function getActivePlugins<T extends { ownedName: string }>(plugins: reado
     throw new Error("No active plugins found. Please set the ACTIVE_PLUGINS environment variable.");
   }
 
-  // TODO: drop an error if the plugin is not found
+  // Check if the requested plugins are valid and can become active
+  const invalidPlugins = pluginsToActivateByOwnedName.filter(
+    (plugin) => !plugins.some((p) => p.ownedName === plugin),
+  );
 
+  if (invalidPlugins.length) {
+    // Throw an error if there are invalid plugins
+    throw new Error(
+      `Invalid plugin names found: ${invalidPlugins.join(
+        ", ",
+      )}. Please check the ACTIVE_PLUGINS environment variable.`,
+    );
+  }
+
+  // Return the active plugins
   return plugins.filter((plugin) => pluginsToActivateByOwnedName.includes(plugin.ownedName));
 }
 

--- a/src/lib/plugin-helpers.ts
+++ b/src/lib/plugin-helpers.ts
@@ -81,3 +81,33 @@ type PluginNamespacePath<T extends PluginNamespacePath = "/"> =
 
 /** @var the requested active plugin name (see `src/plugins` for available plugins) */
 export const ACTIVE_PLUGIN = process.env.ACTIVE_PLUGIN;
+
+/**
+ * Returns the active plugins list based on the `ACTIVE_PLUGIN` environment variable.
+ *
+ * The `ACTIVE_PLUGIN` environment variable is a comma-separated list of plugin
+ * names. The function returns the plugins that are included in the list.
+ *
+ * @param plugins is a list of available plugins
+ * @returns the active plugins
+ */
+export function getActivePlugins<T extends { ownedName: string }>(plugins: readonly T[]): T[] {
+  const pluginsToActivateByOwnedName = ACTIVE_PLUGIN
+    ? ACTIVE_PLUGIN.split(",").map((p) => p.toLowerCase())
+    : [];
+
+  if (!pluginsToActivateByOwnedName.length) {
+    throw new Error("No active plugins found. Please set the ACTIVE_PLUGIN environment variable.");
+  }
+
+  return plugins.filter((plugin) =>
+    pluginsToActivateByOwnedName.includes(plugin.ownedName.toLowerCase()),
+  );
+}
+
+// Helper type to get the intersection of all config types
+export type IntersectionOf<T> = (T extends any ? (x: T) => void : never) extends (
+  x: infer R,
+) => void
+  ? R
+  : never;

--- a/src/lib/plugin-helpers.ts
+++ b/src/lib/plugin-helpers.ts
@@ -80,29 +80,29 @@ type PluginNamespacePath<T extends PluginNamespacePath = "/"> =
   | `/${string}${T}`;
 
 /** @var the requested active plugin name (see `src/plugins` for available plugins) */
-export const ACTIVE_PLUGIN = process.env.ACTIVE_PLUGIN;
+export const ACTIVE_PLUGINS = process.env.ACTIVE_PLUGINS;
 
 /**
- * Returns the active plugins list based on the `ACTIVE_PLUGIN` environment variable.
+ * Returns the active plugins list based on the `ACTIVE_PLUGINS` environment variable.
  *
- * The `ACTIVE_PLUGIN` environment variable is a comma-separated list of plugin
+ * The `ACTIVE_PLUGINS` environment variable is a comma-separated list of plugin
  * names. The function returns the plugins that are included in the list.
  *
  * @param plugins is a list of available plugins
  * @returns the active plugins
  */
 export function getActivePlugins<T extends { ownedName: string }>(plugins: readonly T[]): T[] {
-  const pluginsToActivateByOwnedName = ACTIVE_PLUGIN
-    ? ACTIVE_PLUGIN.split(",").map((p) => p.toLowerCase())
+  const pluginsToActivateByOwnedName = ACTIVE_PLUGINS
+    ? ACTIVE_PLUGINS.split(",").map((p) => p.toLowerCase())
     : [];
 
   if (!pluginsToActivateByOwnedName.length) {
-    throw new Error("No active plugins found. Please set the ACTIVE_PLUGIN environment variable.");
+    throw new Error("No active plugins found. Please set the ACTIVE_PLUGINS environment variable.");
   }
 
-  return plugins.filter((plugin) =>
-    pluginsToActivateByOwnedName.includes(plugin.ownedName.toLowerCase()),
-  );
+  // TODO: drop an error if the plugin is not found
+
+  return plugins.filter((plugin) => pluginsToActivateByOwnedName.includes(plugin.ownedName));
 }
 
 // Helper type to get the intersection of all config types

--- a/src/lib/upserts.ts
+++ b/src/lib/upserts.ts
@@ -3,16 +3,16 @@ import { accounts, registrations, resolvers } from "ponder:schema";
 import type { Address } from "viem";
 
 export async function upsertAccount(context: Context, address: Address) {
-  return await context.db.insert(accounts).values({ id: address }).onConflictDoNothing();
+  return context.db.insert(accounts).values({ id: address }).onConflictDoNothing();
 }
 
 export async function upsertResolver(context: Context, values: typeof resolvers.$inferInsert) {
-  return await context.db.insert(resolvers).values(values).onConflictDoUpdate(values);
+  return context.db.insert(resolvers).values(values).onConflictDoUpdate(values);
 }
 
 export async function upsertRegistration(
   context: Context,
   values: typeof registrations.$inferInsert,
 ) {
-  return await context.db.insert(registrations).values(values).onConflictDoUpdate(values);
+  return context.db.insert(registrations).values(values).onConflictDoUpdate(values);
 }

--- a/src/plugins/README.md
+++ b/src/plugins/README.md
@@ -1,8 +1,8 @@
 # Indexer plugins
 
 This directory contains plugins which allow defining subname-specific processing of blockchain events.
-Only one plugin can be active at a time. Use the `ACTIVE_PLUGIN` env variable to select the active plugin, for example:
+Only one plugin can be active at a time. Use the `ACTIVE_PLUGINS` env variable to select the active plugin, for example:
 
 ```
-ACTIVE_PLUGIN=base.eth
+ACTIVE_PLUGINS=base.eth
 ```

--- a/src/plugins/base.eth/handlers/Registrar.ts
+++ b/src/plugins/base.eth/handlers/Registrar.ts
@@ -45,7 +45,7 @@ export default function () {
   });
   ponder.on(pluginNamespace("BaseRegistrar:NameRenewed"), handleNameRenewed);
 
-  // Base's BaseRegistrar uses `id` instead of `tokenId`
+  // base.eth's BaseRegistrar uses `id` instead of `tokenId`
   ponder.on(pluginNamespace("BaseRegistrar:Transfer"), async ({ context, event }) => {
     if (event.args.from === zeroAddress) {
       /**

--- a/src/plugins/base.eth/handlers/Registrar.ts
+++ b/src/plugins/base.eth/handlers/Registrar.ts
@@ -1,6 +1,7 @@
-import { ponder } from "ponder:registry";
+import { Context, ponder } from "ponder:registry";
 import { domains } from "ponder:schema";
-import { zeroAddress } from "viem";
+import { Block } from "ponder";
+import { Hex, zeroAddress } from "viem";
 import { makeRegistrarHandlers } from "../../../handlers/Registrar";
 import { makeSubnodeNamehash, tokenIdToLabel } from "../../../lib/subname-helpers";
 import { upsertAccount } from "../../../lib/upserts";
@@ -15,6 +16,33 @@ const {
   ownedSubnameNode,
 } = makeRegistrarHandlers(ownedName);
 
+/**
+ * Idempotent handler to insert a domain record when a new domain is
+ * initialized. For example, right after an NFT token for the domain
+ * is minted.
+ *
+ * @returns a newly created domain record
+ */
+function handleDomainNameInitialized({
+  context,
+  event,
+}: {
+  context: Context;
+  event: { args: { id: bigint; owner: Hex }; block: Block };
+}) {
+  const { id, owner } = event.args;
+  const label = tokenIdToLabel(id);
+  const node = makeSubnodeNamehash(ownedSubnameNode, label);
+  return context.db
+    .insert(domains)
+    .values({
+      id: node,
+      ownerId: owner,
+      createdAt: event.block.timestamp,
+    })
+    .onConflictDoNothing();
+}
+
 export default function () {
   // support NameRegisteredWithRecord for BaseRegistrar as it used by Base's RegistrarControllers
   ponder.on(pluginNamespace("BaseRegistrar:NameRegisteredWithRecord"), async ({ context, event }) =>
@@ -22,62 +50,48 @@ export default function () {
   );
 
   ponder.on(pluginNamespace("BaseRegistrar:NameRegistered"), async ({ context, event }) => {
+    await upsertAccount(context, event.args.owner);
     // base has 'preminted' names via Registrar#registerOnly, which explicitly does not update Registry.
     // this breaks a subgraph assumption, as it expects a domain to exist (via Registry:NewOwner) before
     // any Registrar:NameRegistered events. in the future we will likely happily upsert domains, but
     // in order to avoid prematurely drifting from subgraph equivalancy, we upsert the domain here,
     // allowing the base indexer to progress.
-    const { id, owner } = event.args;
-    const label = tokenIdToLabel(id);
-    const node = makeSubnodeNamehash(ownedSubnameNode, label);
-    await upsertAccount(context, owner);
-    await context.db
-      .insert(domains)
-      .values({
-        id: node,
-        ownerId: owner,
-        createdAt: event.block.timestamp,
-      })
-      .onConflictDoNothing();
+    await handleDomainNameInitialized({ context, event });
 
     // after ensuring the domain exists, continue with the standard handler
     return handleNameRegistered({ context, event });
   });
   ponder.on(pluginNamespace("BaseRegistrar:NameRenewed"), handleNameRenewed);
 
-  // base.eth's BaseRegistrar uses `id` instead of `tokenId`
   ponder.on(pluginNamespace("BaseRegistrar:Transfer"), async ({ context, event }) => {
+    const { id, from, to } = event.args;
+
     if (event.args.from === zeroAddress) {
-      /**
-       * Address the issue where in the same transaction the Transfer event occurs before the NameRegistered event.
-       * Example: https://basescan.org/tx/0x4d478a75710fb1edcfad5289b9e5ba76c4d1a0e8d897e2e89adf6d8107aadd66#eventlog
-       * Code: https://github.com/base-org/basenames/blob/1b5c1ad464f061c557c33b60b1821f75dae924cc/src/L2/BaseRegistrar.sol#L272-L273
-       */
-
-      const { id, to: owner } = event.args;
-      const label = tokenIdToLabel(id);
-      const node = makeSubnodeNamehash(ownedSubnameNode, label);
-
-      await context.db
-        .insert(domains)
-        .values({
-          id: node,
-          ownerId: owner,
-          createdAt: event.block.timestamp,
-        })
-        .onConflictDoNothing();
+      // The ens-subgraph `handleNameTransferred` handler implementation
+      // assumes the domain record exists. However, when an NFT token is
+      // minted, there's no domain record yet created. The very first transfer
+      // event has to initialize the domain record. This is a workaround to
+      // meet the subgraph implementation expectations.
+      await handleDomainNameInitialized({
+        context,
+        event: {
+          ...event,
+          args: { id, owner: to },
+        },
+      });
     }
 
+    // base.eth's BaseRegistrar uses `id` instead of `tokenId`
     await handleNameTransferred({
       context,
-      args: { ...event.args, tokenId: event.args.id },
+      args: { from, to, tokenId: id },
     });
   });
 
   ponder.on(pluginNamespace("EARegistrarController:NameRegistered"), async ({ context, event }) => {
     // TODO: registration expected here
 
-    return handleNameRegisteredByController({
+    await handleNameRegisteredByController({
       context,
       args: { ...event.args, cost: 0n },
     });
@@ -86,14 +100,14 @@ export default function () {
   ponder.on(pluginNamespace("RegistrarController:NameRegistered"), async ({ context, event }) => {
     // TODO: registration expected here
 
-    return handleNameRegisteredByController({
+    await handleNameRegisteredByController({
       context,
       args: { ...event.args, cost: 0n },
     });
   });
 
   ponder.on(pluginNamespace("RegistrarController:NameRenewed"), async ({ context, event }) => {
-    return handleNameRenewedByController({
+    await handleNameRenewedByController({
       context,
       args: { ...event.args, cost: 0n },
     });

--- a/src/plugins/base.eth/ponder.config.ts
+++ b/src/plugins/base.eth/ponder.config.ts
@@ -16,7 +16,7 @@ export const pluginNamespace = createPluginNamespace(ownedName);
 
 // constrain the ponder indexing between the following start/end blocks
 // https://ponder.sh/0_6/docs/contracts-and-networks#block-range
-const START_BLOCK: ContractConfig["startBlock"] = 24944146;
+const START_BLOCK: ContractConfig["startBlock"] = undefined;
 const END_BLOCK: ContractConfig["endBlock"] = undefined;
 
 export const config = createConfig({
@@ -24,6 +24,7 @@ export const config = createConfig({
     base: {
       chainId: base.id,
       transport: http(process.env[`RPC_URL_${base.id}`]),
+      maxRequestsPerSecond: 250,
     },
   },
   contracts: {

--- a/src/plugins/base.eth/ponder.config.ts
+++ b/src/plugins/base.eth/ponder.config.ts
@@ -1,7 +1,8 @@
-import { createConfig, factory } from "ponder";
+import { type ContractConfig, createConfig, factory } from "ponder";
 import { http, getAbiItem } from "viem";
 import { base } from "viem/chains";
 
+import { blockConfig } from "../../lib/helpers";
 import { createPluginNamespace } from "../../lib/plugin-helpers";
 import { BaseRegistrar } from "./abis/BaseRegistrar";
 import { EarlyAccessRegistrarController } from "./abis/EARegistrarController";
@@ -12,6 +13,11 @@ import { Registry } from "./abis/Registry";
 export const ownedName = "base.eth" as const;
 
 export const pluginNamespace = createPluginNamespace(ownedName);
+
+// constrain the ponder indexing between the following start/end blocks
+// https://ponder.sh/0_6/docs/contracts-and-networks#block-range
+const START_BLOCK: ContractConfig["startBlock"] = 24944146;
+const END_BLOCK: ContractConfig["endBlock"] = undefined;
 
 export const config = createConfig({
   networks: {
@@ -25,7 +31,7 @@ export const config = createConfig({
       network: "base",
       abi: Registry,
       address: "0xb94704422c2a1e396835a571837aa5ae53285a95",
-      startBlock: 17571480,
+      ...blockConfig(START_BLOCK, 17571480, END_BLOCK),
     },
     [pluginNamespace("Resolver")]: {
       network: "base",
@@ -35,25 +41,25 @@ export const config = createConfig({
         event: getAbiItem({ abi: Registry, name: "NewResolver" }),
         parameter: "resolver",
       }),
-      startBlock: 17575714,
+      ...blockConfig(START_BLOCK, 17575714, END_BLOCK),
     },
     [pluginNamespace("BaseRegistrar")]: {
       network: "base",
       abi: BaseRegistrar,
       address: "0x03c4738Ee98aE44591e1A4A4F3CaB6641d95DD9a",
-      startBlock: 17571486,
+      ...blockConfig(START_BLOCK, 17571486, END_BLOCK),
     },
     [pluginNamespace("EARegistrarController")]: {
       network: "base",
       abi: EarlyAccessRegistrarController,
       address: "0xd3e6775ed9b7dc12b205c8e608dc3767b9e5efda",
-      startBlock: 17575699,
+      ...blockConfig(START_BLOCK, 17575699, END_BLOCK),
     },
     [pluginNamespace("RegistrarController")]: {
       network: "base",
       abi: RegistrarController,
       address: "0x4cCb0BB02FCABA27e82a56646E81d8c5bC4119a5",
-      startBlock: 18619035,
+      ...blockConfig(START_BLOCK, 18619035, END_BLOCK),
     },
   },
 });

--- a/src/plugins/eth/handlers/EthRegistrar.ts
+++ b/src/plugins/eth/handlers/EthRegistrar.ts
@@ -15,20 +15,20 @@ export default function () {
   ponder.on(pluginNamespace("BaseRegistrar:NameRenewed"), handleNameRenewed);
 
   ponder.on(pluginNamespace("BaseRegistrar:Transfer"), async ({ context, event }) => {
-    return await handleNameTransferred({ context, args: event.args });
+    await handleNameTransferred({ context, args: event.args });
   });
 
   ponder.on(
     pluginNamespace("EthRegistrarControllerOld:NameRegistered"),
     async ({ context, event }) => {
       // the old registrar controller just had `cost` param
-      return await handleNameRegisteredByController({ context, args: event.args });
+      await handleNameRegisteredByController({ context, args: event.args });
     },
   );
   ponder.on(
     pluginNamespace("EthRegistrarControllerOld:NameRenewed"),
     async ({ context, event }) => {
-      return await handleNameRenewedByController({ context, args: event.args });
+      await handleNameRenewedByController({ context, args: event.args });
     },
   );
 
@@ -36,7 +36,7 @@ export default function () {
     pluginNamespace("EthRegistrarController:NameRegistered"),
     async ({ context, event }) => {
       // the new registrar controller uses baseCost + premium to compute cost
-      return await handleNameRegisteredByController({
+      await handleNameRegisteredByController({
         context,
         args: {
           ...event.args,
@@ -46,6 +46,6 @@ export default function () {
     },
   );
   ponder.on(pluginNamespace("EthRegistrarController:NameRenewed"), async ({ context, event }) => {
-    return await handleNameRenewedByController({ context, args: event.args });
+    await handleNameRenewedByController({ context, args: event.args });
   });
 }

--- a/src/plugins/eth/ponder.config.ts
+++ b/src/plugins/eth/ponder.config.ts
@@ -20,7 +20,7 @@ export const pluginNamespace = createPluginNamespace(ownedName);
 
 // constrain the ponder indexing between the following start/end blocks
 // https://ponder.sh/0_6/docs/contracts-and-networks#block-range
-const START_BLOCK: ContractConfig["startBlock"] = 21_610_000;
+const START_BLOCK: ContractConfig["startBlock"] = undefined;
 const END_BLOCK: ContractConfig["endBlock"] = undefined;
 
 export const config = createConfig({
@@ -28,6 +28,7 @@ export const config = createConfig({
     mainnet: {
       chainId: mainnet.id,
       transport: http(process.env[`RPC_URL_${mainnet.id}`]),
+      maxRequestsPerSecond: 250,
     },
   },
   contracts: {

--- a/src/plugins/eth/ponder.config.ts
+++ b/src/plugins/eth/ponder.config.ts
@@ -20,7 +20,7 @@ export const pluginNamespace = createPluginNamespace(ownedName);
 
 // constrain the ponder indexing between the following start/end blocks
 // https://ponder.sh/0_6/docs/contracts-and-networks#block-range
-const START_BLOCK: ContractConfig["startBlock"] = undefined;
+const START_BLOCK: ContractConfig["startBlock"] = 21_610_000;
 const END_BLOCK: ContractConfig["endBlock"] = undefined;
 
 export const config = createConfig({

--- a/src/plugins/linea.eth/handlers/EthRegistrar.ts
+++ b/src/plugins/linea.eth/handlers/EthRegistrar.ts
@@ -22,8 +22,8 @@ export default function () {
     if (event.args.from === zeroAddress) {
       /**
        * Address the issue where in the same transaction the Transfer event occurs before the NameRegistered event.
-       * Example: https://basescan.org/tx/0x4d478a75710fb1edcfad5289b9e5ba76c4d1a0e8d897e2e89adf6d8107aadd66#eventlog
-       * Code: https://github.com/base-org/basenames/blob/1b5c1ad464f061c557c33b60b1821f75dae924cc/src/L2/BaseRegistrar.sol#L272-L273
+       * Example: https://lineascan.build/tx/0x2211c5d857d16b7ac111088c57fb346ab94049cb297f02b0dda7aaf4c14d305b#eventlog
+       * Code: hhttps://github.com/Consensys/linea-ens/blob/main/packages/linea-ens-contracts/contracts/ethregistrar/BaseRegistrarImplementation.sol#L155-L160
        */
 
       const { tokenId: id, to: owner } = event.args;

--- a/src/plugins/linea.eth/handlers/EthRegistrar.ts
+++ b/src/plugins/linea.eth/handlers/EthRegistrar.ts
@@ -23,7 +23,7 @@ export default function () {
       /**
        * Address the issue where in the same transaction the Transfer event occurs before the NameRegistered event.
        * Example: https://lineascan.build/tx/0x2211c5d857d16b7ac111088c57fb346ab94049cb297f02b0dda7aaf4c14d305b#eventlog
-       * Code: hhttps://github.com/Consensys/linea-ens/blob/main/packages/linea-ens-contracts/contracts/ethregistrar/BaseRegistrarImplementation.sol#L155-L160
+       * Code: https://github.com/Consensys/linea-ens/blob/main/packages/linea-ens-contracts/contracts/ethregistrar/BaseRegistrarImplementation.sol#L155-L160
        */
 
       const { tokenId: id, to: owner } = event.args;

--- a/src/plugins/linea.eth/ponder.config.ts
+++ b/src/plugins/linea.eth/ponder.config.ts
@@ -16,8 +16,8 @@ export const pluginNamespace = createPluginNamespace(ownedName);
 
 // constrain the ponder indexing between the following start/end blocks
 // https://ponder.sh/0_6/docs/contracts-and-networks#block-range
-const START_BLOCK: ContractConfig["startBlock"] = undefined;
-const END_BLOCK: ContractConfig["endBlock"] = 8398631;
+const START_BLOCK: ContractConfig["startBlock"] = 14490289;
+const END_BLOCK: ContractConfig["endBlock"] = undefined;
 
 export const config = createConfig({
   networks: {

--- a/src/plugins/linea.eth/ponder.config.ts
+++ b/src/plugins/linea.eth/ponder.config.ts
@@ -17,7 +17,7 @@ export const pluginNamespace = createPluginNamespace(ownedName);
 // constrain the ponder indexing between the following start/end blocks
 // https://ponder.sh/0_6/docs/contracts-and-networks#block-range
 const START_BLOCK: ContractConfig["startBlock"] = undefined;
-const END_BLOCK: ContractConfig["endBlock"] = undefined;
+const END_BLOCK: ContractConfig["endBlock"] = 8398631;
 
 export const config = createConfig({
   networks: {

--- a/src/plugins/linea.eth/ponder.config.ts
+++ b/src/plugins/linea.eth/ponder.config.ts
@@ -16,7 +16,7 @@ export const pluginNamespace = createPluginNamespace(ownedName);
 
 // constrain the ponder indexing between the following start/end blocks
 // https://ponder.sh/0_6/docs/contracts-and-networks#block-range
-const START_BLOCK: ContractConfig["startBlock"] = 14490289;
+const START_BLOCK: ContractConfig["startBlock"] = undefined;
 const END_BLOCK: ContractConfig["endBlock"] = undefined;
 
 export const config = createConfig({
@@ -24,6 +24,7 @@ export const config = createConfig({
     linea: {
       chainId: linea.id,
       transport: http(process.env[`RPC_URL_${linea.id}`]),
+      maxRequestsPerSecond: 250,
     },
   },
   contracts: {


### PR DESCRIPTION
This PR allows cross-subname indexing. For example. with this change, it's possible to get a list of all names a given address owns across multiple subnames (i.e. `base.eth`, `linea.eth`).

### Example query

```gql
query GetOwnedDomains($ownerAddreess: String!) {
  domainss(
    where: {OR: [{ownerId: $ownerAddreess}, {wrappedOwnerId: $ownerAddreess}]}
  ) {
    items {
      labelName
      name
      ownerId
      wrappedOwnerId
      createdAt
      expiryDate
    }
  }
}
```

### Preview

Domain names under `eth`, `base.eth`, and `linea.eth`:
![image](https://github.com/user-attachments/assets/0ee57715-d004-4113-bf9b-16318958bcd1)
