### PR TITLE
singularize schema table names

### DIFF
--- a/ponder.schema.ts
+++ b/ponder.schema.ts
@@ -1,7 +1,7 @@
 import { onchainTable, relations } from "ponder";
 import type { Address } from "viem";
 
-export const domains = onchainTable("domains", (t) => ({
+export const domain = onchainTable("domains", (t) => ({
   // The namehash of the name
   id: t.hex().primaryKey(),
   // The human readable name, if known. Unknown portions replaced with hash in square brackets (eg, foo.[1234].eth)
@@ -44,55 +44,55 @@ export const domains = onchainTable("domains", (t) => ({
   // events: [DomainEvent!]! @derivedFrom(field: "domain")
 }));
 
-export const domainRelations = relations(domains, ({ one, many }) => ({
+export const domainRelations = relations(domain, ({ one, many }) => ({
   // has one owner
-  owner: one(accounts, {
-    fields: [domains.ownerId],
-    references: [accounts.id],
+  owner: one(account, {
+    fields: [domain.ownerId],
+    references: [account.id],
   }),
-  parent: one(domains, {
-    fields: [domains.parentId],
-    references: [domains.id],
+  parent: one(domain, {
+    fields: [domain.parentId],
+    references: [domain.id],
   }),
-  resolver: one(resolvers, {
-    fields: [domains.resolverId],
-    references: [resolvers.id],
+  resolver: one(resolver, {
+    fields: [domain.resolverId],
+    references: [resolver.id],
   }),
-  subdomains: many(domains, { relationName: "parent" }),
-  registrant: one(accounts, {
-    fields: [domains.registrantId],
-    references: [accounts.id],
+  subdomains: many(domain, { relationName: "parent" }),
+  registrant: one(account, {
+    fields: [domain.registrantId],
+    references: [account.id],
   }),
-  wrappedOwner: one(accounts, {
-    fields: [domains.wrappedOwnerId],
-    references: [accounts.id],
+  wrappedOwner: one(account, {
+    fields: [domain.wrappedOwnerId],
+    references: [account.id],
   }),
 
   // The wrapped domain associated with the domain
-  wrappedDomain: one(wrappedDomains, {
-    fields: [domains.id],
-    references: [wrappedDomains.domainId],
+  wrappedDomain: one(wrappedDomain, {
+    fields: [domain.id],
+    references: [wrappedDomain.domainId],
   }),
 
   // The registration associated with the domain
-  registration: one(registrations, {
-    fields: [domains.id],
-    references: [registrations.domainId],
+  registration: one(registration, {
+    fields: [domain.id],
+    references: [registration.domainId],
   }),
 }));
 
-export const accounts = onchainTable("accounts", (t) => ({
+export const account = onchainTable("accounts", (t) => ({
   id: t.hex().primaryKey(),
 }));
 
-export const accountsRelations = relations(accounts, ({ many }) => ({
+export const accountRelations = relations(account, ({ many }) => ({
   // account has many domains
-  domains: many(domains),
+  domains: many(domain),
   // TODO: has many wrapped domains
   // TODO: has many registrations
 }));
 
-export const resolvers = onchainTable("resolvers", (t) => ({
+export const resolver = onchainTable("resolvers", (t) => ({
   // The unique identifier for this resolver, which is a concatenation of the domain namehash and the resolver address
   id: t.text().primaryKey(),
   // The domain that this resolver is associated with
@@ -112,18 +112,18 @@ export const resolvers = onchainTable("resolvers", (t) => ({
   // TODO: has many events
 }));
 
-export const resolverRelations = relations(resolvers, ({ one }) => ({
-  addr: one(accounts, {
-    fields: [resolvers.addrId],
-    references: [accounts.id],
+export const resolverRelations = relations(resolver, ({ one }) => ({
+  addr: one(account, {
+    fields: [resolver.addrId],
+    references: [account.id],
   }),
-  domain: one(domains, {
-    fields: [resolvers.domainId],
-    references: [domains.id],
+  domain: one(domain, {
+    fields: [resolver.domainId],
+    references: [domain.id],
   }),
 }));
 
-export const registrations = onchainTable("registrations", (t) => ({
+export const registration = onchainTable("registrations", (t) => ({
   // The unique identifier of the registration
   id: t.hex().primaryKey(),
   // The domain name associated with the registration
@@ -143,18 +143,18 @@ export const registrations = onchainTable("registrations", (t) => ({
   // TODO: events
 }));
 
-export const registrationRelations = relations(registrations, ({ one }) => ({
-  domain: one(domains, {
-    fields: [registrations.domainId],
-    references: [domains.id],
+export const registrationRelations = relations(registration, ({ one }) => ({
+  domain: one(domain, {
+    fields: [registration.domainId],
+    references: [domain.id],
   }),
-  registrant: one(accounts, {
-    fields: [registrations.registrantId],
-    references: [accounts.id],
+  registrant: one(account, {
+    fields: [registration.registrantId],
+    references: [account.id],
   }),
 }));
 
-export const wrappedDomains = onchainTable("wrapped_domains", (t) => ({
+export const wrappedDomain = onchainTable("wrapped_domains", (t) => ({
   // The unique identifier for each instance of the WrappedDomain entity
   id: t.hex().primaryKey(),
   // The domain that is wrapped by this WrappedDomain
@@ -169,13 +169,13 @@ export const wrappedDomains = onchainTable("wrapped_domains", (t) => ({
   name: t.text(),
 }));
 
-export const wrappedDomainRelations = relations(wrappedDomains, ({ one }) => ({
-  domain: one(domains, {
-    fields: [wrappedDomains.domainId],
-    references: [domains.id],
+export const wrappedDomainRelations = relations(wrappedDomain, ({ one }) => ({
+  domain: one(domain, {
+    fields: [wrappedDomain.domainId],
+    references: [domain.id],
   }),
-  owner: one(accounts, {
-    fields: [wrappedDomains.ownerId],
-    references: [accounts.id],
+  owner: one(account, {
+    fields: [wrappedDomain.ownerId],
+    references: [account.id],
   }),
 }));

--- a/src/handlers/NameWrapper.ts
+++ b/src/handlers/NameWrapper.ts
@@ -9,7 +9,7 @@ import { upsertAccount } from "../lib/upserts";
 
 // if the wrappedDomain in question has pcc burned (?) and a higher (?) expiry date, update the domain's expiryDate
 async function materializeDomainExpiryDate(context: Context, node: Hex) {
-  const wrappedDomain = await context.db.find(schema.wrappedDomains, { id: node });
+  const wrappedDomain = await context.db.find(schema.wrappedDomain, { id: node });
   if (!wrappedDomain) throw new Error(`Expected WrappedDomain(${node})`);
 
   // NOTE: the subgraph has a helper function called [checkPccBurned](https://github.com/ensdomains/ens-subgraph/blob/master/src/nameWrapper.ts#L63)
@@ -22,7 +22,7 @@ async function materializeDomainExpiryDate(context: Context, node: Hex) {
   if (checkPccBurned(BigInt(wrappedDomain.fuses))) return;
 
   // update the domain's expiry to the greater of the two
-  await context.db.update(schema.domains, { id: node }).set((domain) => ({
+  await context.db.update(schema.domain, { id: node }).set((domain) => ({
     expiryDate: bigintMax(domain.expiryDate ?? 0n, wrappedDomain.expiryDate),
   }));
 }
@@ -38,7 +38,7 @@ async function handleTransfer(
   const node = tokenIdToLabel(tokenId);
 
   // TODO: remove this if it never fires: subgraph upserts domain but shouldn't be necessary
-  const domain = await context.db.find(schema.domains, { id: node });
+  const domain = await context.db.find(schema.domain, { id: node });
   if (!domain) {
     console.log("NameWrapper:handleTransfer called before domain existed");
     console.table({ ...event.args, node });
@@ -46,7 +46,7 @@ async function handleTransfer(
 
   // upsert the WrappedDomain, only changing owner iff exists
   await context.db
-    .insert(schema.wrappedDomains)
+    .insert(schema.wrappedDomain)
     .values({
       id: node,
       ownerId: to,
@@ -91,18 +91,18 @@ export const makeNameWrapperHandlers = (ownedName: `${string}eth`) => {
 
       // upsert the healed name iff valid
       if (label) {
-        await context.db.update(schema.domains, { id: node }).set({ labelName: label, name });
+        await context.db.update(schema.domain, { id: node }).set({ labelName: label, name });
       }
 
       // update the WrappedDomain that was created in handleTransfer
-      await context.db.update(schema.wrappedDomains, { id: node }).set({
+      await context.db.update(schema.wrappedDomain, { id: node }).set({
         name,
         expiryDate: expiry,
         fuses,
       });
 
       // materialize wrappedOwner relation
-      await context.db.update(schema.domains, { id: node }).set({ wrappedOwnerId: owner });
+      await context.db.update(schema.domain, { id: node }).set({ wrappedOwnerId: owner });
 
       // materialize domain expiryDate
       await materializeDomainExpiryDate(context, node);
@@ -126,7 +126,7 @@ export const makeNameWrapperHandlers = (ownedName: `${string}eth`) => {
 
       await upsertAccount(context, owner);
 
-      await context.db.update(schema.domains, { id: node }).set((domain) => ({
+      await context.db.update(schema.domain, { id: node }).set((domain) => ({
         // null expiry date if the domain is not a direct child of .eth
         // https://github.com/ensdomains/ens-subgraph/blob/master/src/nameWrapper.ts#L123
         ...(domain.expiryDate && domain.parentId !== ownedSubnameNode && { expiryDate: null }),
@@ -135,7 +135,7 @@ export const makeNameWrapperHandlers = (ownedName: `${string}eth`) => {
       }));
 
       // delete the WrappedDomain
-      await context.db.delete(schema.wrappedDomains, { id: node });
+      await context.db.delete(schema.wrappedDomain, { id: node });
 
       // TODO: log NameUnwrapped
     },
@@ -156,7 +156,7 @@ export const makeNameWrapperHandlers = (ownedName: `${string}eth`) => {
 
       // NOTE: subgraph does an implicit ignore if no WrappedDomain record.
       // we will be more explicit and update logic if necessary
-      await context.db.update(schema.wrappedDomains, { id: node }).set({ fuses });
+      await context.db.update(schema.wrappedDomain, { id: node }).set({ fuses });
     },
     async handleExpiryExtended({
       context,
@@ -174,7 +174,7 @@ export const makeNameWrapperHandlers = (ownedName: `${string}eth`) => {
 
       // NOTE: subgraph does an implicit ignore if no WrappedDomain record.
       // we will be more explicit and update logic if necessary
-      await context.db.update(schema.wrappedDomains, { id: node }).set({ expiryDate: expiry });
+      await context.db.update(schema.wrappedDomain, { id: node }).set({ expiryDate: expiry });
 
       // materialize the domain's expiryDate
       await materializeDomainExpiryDate(context, node);

--- a/src/handlers/NameWrapper.ts
+++ b/src/handlers/NameWrapper.ts
@@ -1,5 +1,5 @@
 import { type Context, type Event, type EventNames } from "ponder:registry";
-import { domains, wrappedDomains } from "ponder:schema";
+import schema from "ponder:schema";
 import { checkPccBurned } from "@ensdomains/ensjs/utils";
 import { type Address, type Hex, hexToBytes, namehash } from "viem";
 import { bigintMax } from "../lib/helpers";
@@ -9,7 +9,7 @@ import { upsertAccount } from "../lib/upserts";
 
 // if the wrappedDomain in question has pcc burned (?) and a higher (?) expiry date, update the domain's expiryDate
 async function materializeDomainExpiryDate(context: Context, node: Hex) {
-  const wrappedDomain = await context.db.find(wrappedDomains, { id: node });
+  const wrappedDomain = await context.db.find(schema.wrappedDomains, { id: node });
   if (!wrappedDomain) throw new Error(`Expected WrappedDomain(${node})`);
 
   // NOTE: the subgraph has a helper function called [checkPccBurned](https://github.com/ensdomains/ens-subgraph/blob/master/src/nameWrapper.ts#L63)
@@ -22,7 +22,7 @@ async function materializeDomainExpiryDate(context: Context, node: Hex) {
   if (checkPccBurned(BigInt(wrappedDomain.fuses))) return;
 
   // update the domain's expiry to the greater of the two
-  await context.db.update(domains, { id: node }).set((domain) => ({
+  await context.db.update(schema.domains, { id: node }).set((domain) => ({
     expiryDate: bigintMax(domain.expiryDate ?? 0n, wrappedDomain.expiryDate),
   }));
 }
@@ -38,7 +38,7 @@ async function handleTransfer(
   const node = tokenIdToLabel(tokenId);
 
   // TODO: remove this if it never fires: subgraph upserts domain but shouldn't be necessary
-  const domain = await context.db.find(domains, { id: node });
+  const domain = await context.db.find(schema.domains, { id: node });
   if (!domain) {
     console.log("NameWrapper:handleTransfer called before domain existed");
     console.table({ ...event.args, node });
@@ -46,7 +46,7 @@ async function handleTransfer(
 
   // upsert the WrappedDomain, only changing owner iff exists
   await context.db
-    .insert(wrappedDomains)
+    .insert(schema.wrappedDomains)
     .values({
       id: node,
       ownerId: to,
@@ -91,18 +91,18 @@ export const makeNameWrapperHandlers = (ownedName: `${string}eth`) => {
 
       // upsert the healed name iff valid
       if (label) {
-        await context.db.update(domains, { id: node }).set({ labelName: label, name });
+        await context.db.update(schema.domains, { id: node }).set({ labelName: label, name });
       }
 
       // update the WrappedDomain that was created in handleTransfer
-      await context.db.update(wrappedDomains, { id: node }).set({
+      await context.db.update(schema.wrappedDomains, { id: node }).set({
         name,
         expiryDate: expiry,
         fuses,
       });
 
       // materialize wrappedOwner relation
-      await context.db.update(domains, { id: node }).set({ wrappedOwnerId: owner });
+      await context.db.update(schema.domains, { id: node }).set({ wrappedOwnerId: owner });
 
       // materialize domain expiryDate
       await materializeDomainExpiryDate(context, node);
@@ -126,7 +126,7 @@ export const makeNameWrapperHandlers = (ownedName: `${string}eth`) => {
 
       await upsertAccount(context, owner);
 
-      await context.db.update(domains, { id: node }).set((domain) => ({
+      await context.db.update(schema.domains, { id: node }).set((domain) => ({
         // null expiry date if the domain is not a direct child of .eth
         // https://github.com/ensdomains/ens-subgraph/blob/master/src/nameWrapper.ts#L123
         ...(domain.expiryDate && domain.parentId !== ownedSubnameNode && { expiryDate: null }),
@@ -135,7 +135,7 @@ export const makeNameWrapperHandlers = (ownedName: `${string}eth`) => {
       }));
 
       // delete the WrappedDomain
-      await context.db.delete(wrappedDomains, { id: node });
+      await context.db.delete(schema.wrappedDomains, { id: node });
 
       // TODO: log NameUnwrapped
     },
@@ -156,7 +156,7 @@ export const makeNameWrapperHandlers = (ownedName: `${string}eth`) => {
 
       // NOTE: subgraph does an implicit ignore if no WrappedDomain record.
       // we will be more explicit and update logic if necessary
-      await context.db.update(wrappedDomains, { id: node }).set({ fuses });
+      await context.db.update(schema.wrappedDomains, { id: node }).set({ fuses });
     },
     async handleExpiryExtended({
       context,
@@ -174,7 +174,7 @@ export const makeNameWrapperHandlers = (ownedName: `${string}eth`) => {
 
       // NOTE: subgraph does an implicit ignore if no WrappedDomain record.
       // we will be more explicit and update logic if necessary
-      await context.db.update(wrappedDomains, { id: node }).set({ expiryDate: expiry });
+      await context.db.update(schema.wrappedDomains, { id: node }).set({ expiryDate: expiry });
 
       // materialize the domain's expiryDate
       await materializeDomainExpiryDate(context, node);

--- a/src/handlers/Registrar.ts
+++ b/src/handlers/Registrar.ts
@@ -17,16 +17,16 @@ export const makeRegistrarHandlers = (ownedName: `${string}eth`) => {
     if (!isLabelIndexable(name)) return;
 
     const node = makeSubnodeNamehash(ownedSubnameNode, label);
-    const domain = await context.db.find(schema.domains, { id: node });
+    const domain = await context.db.find(schema.domain, { id: node });
     if (!domain) throw new Error("domain expected");
 
     if (domain.labelName !== name) {
       await context.db
-        .update(schema.domains, { id: node })
+        .update(schema.domain, { id: node })
         .set({ labelName: name, name: `${name}${ownedName}` });
     }
 
-    await context.db.update(schema.registrations, { id: label }).set({ labelName: name, cost });
+    await context.db.update(schema.registration, { id: label }).set({ labelName: name, cost });
   }
 
   return {
@@ -63,7 +63,7 @@ export const makeRegistrarHandlers = (ownedName: `${string}eth`) => {
         labelName,
       });
 
-      await context.db.update(schema.domains, { id: node }).set({
+      await context.db.update(schema.domain, { id: node }).set({
         registrantId: owner,
         expiryDate: expires + GRACE_PERIOD_SECONDS,
         labelName,
@@ -106,10 +106,10 @@ export const makeRegistrarHandlers = (ownedName: `${string}eth`) => {
       const label = tokenIdToLabel(id);
       const node = makeSubnodeNamehash(ownedSubnameNode, label);
 
-      await context.db.update(schema.registrations, { id: label }).set({ expiryDate: expires });
+      await context.db.update(schema.registration, { id: label }).set({ expiryDate: expires });
 
       await context.db
-        .update(schema.domains, { id: node })
+        .update(schema.domain, { id: node })
         .set({ expiryDate: expires + GRACE_PERIOD_SECONDS });
 
       // TODO: log Event
@@ -131,12 +131,12 @@ export const makeRegistrarHandlers = (ownedName: `${string}eth`) => {
       const label = tokenIdToLabel(tokenId);
       const node = makeSubnodeNamehash(ownedSubnameNode, label);
 
-      const registration = await context.db.find(schema.registrations, { id: label });
+      const registration = await context.db.find(schema.registration, { id: label });
       if (!registration) return;
 
-      await context.db.update(schema.registrations, { id: label }).set({ registrantId: to });
+      await context.db.update(schema.registration, { id: label }).set({ registrantId: to });
 
-      await context.db.update(schema.domains, { id: node }).set({ registrantId: to });
+      await context.db.update(schema.domain, { id: node }).set({ registrantId: to });
 
       // TODO: log Event
     },

--- a/src/handlers/Registrar.ts
+++ b/src/handlers/Registrar.ts
@@ -1,5 +1,5 @@
 import { type Context } from "ponder:registry";
-import { domains, registrations } from "ponder:schema";
+import schema from "ponder:schema";
 import { Block } from "ponder";
 import { type Hex, namehash } from "viem";
 import { isLabelIndexable, makeSubnodeNamehash, tokenIdToLabel } from "../lib/subname-helpers";
@@ -17,16 +17,16 @@ export const makeRegistrarHandlers = (ownedName: `${string}eth`) => {
     if (!isLabelIndexable(name)) return;
 
     const node = makeSubnodeNamehash(ownedSubnameNode, label);
-    const domain = await context.db.find(domains, { id: node });
+    const domain = await context.db.find(schema.domains, { id: node });
     if (!domain) throw new Error("domain expected");
 
     if (domain.labelName !== name) {
       await context.db
-        .update(domains, { id: node })
+        .update(schema.domains, { id: node })
         .set({ labelName: name, name: `${name}${ownedName}` });
     }
 
-    await context.db.update(registrations, { id: label }).set({ labelName: name, cost });
+    await context.db.update(schema.registrations, { id: label }).set({ labelName: name, cost });
   }
 
   return {
@@ -63,7 +63,7 @@ export const makeRegistrarHandlers = (ownedName: `${string}eth`) => {
         labelName,
       });
 
-      await context.db.update(domains, { id: node }).set({
+      await context.db.update(schema.domains, { id: node }).set({
         registrantId: owner,
         expiryDate: expires + GRACE_PERIOD_SECONDS,
         labelName,
@@ -106,10 +106,10 @@ export const makeRegistrarHandlers = (ownedName: `${string}eth`) => {
       const label = tokenIdToLabel(id);
       const node = makeSubnodeNamehash(ownedSubnameNode, label);
 
-      await context.db.update(registrations, { id: label }).set({ expiryDate: expires });
+      await context.db.update(schema.registrations, { id: label }).set({ expiryDate: expires });
 
       await context.db
-        .update(domains, { id: node })
+        .update(schema.domains, { id: node })
         .set({ expiryDate: expires + GRACE_PERIOD_SECONDS });
 
       // TODO: log Event
@@ -131,12 +131,12 @@ export const makeRegistrarHandlers = (ownedName: `${string}eth`) => {
       const label = tokenIdToLabel(tokenId);
       const node = makeSubnodeNamehash(ownedSubnameNode, label);
 
-      const registration = await context.db.find(registrations, { id: label });
+      const registration = await context.db.find(schema.registrations, { id: label });
       if (!registration) return;
 
-      await context.db.update(registrations, { id: label }).set({ registrantId: to });
+      await context.db.update(schema.registrations, { id: label }).set({ registrantId: to });
 
-      await context.db.update(domains, { id: node }).set({ registrantId: to });
+      await context.db.update(schema.domains, { id: node }).set({ registrantId: to });
 
       // TODO: log Event
     },

--- a/src/handlers/Registry.ts
+++ b/src/handlers/Registry.ts
@@ -1,5 +1,5 @@
 import { Context } from "ponder:registry";
-import { domains, resolvers } from "ponder:schema";
+import schema from "ponder:schema";
 import { encodeLabelhash } from "@ensdomains/ensjs/utils";
 import { Block } from "ponder";
 import { type Hex, zeroAddress } from "viem";
@@ -15,7 +15,7 @@ export async function setupRootNode({ context }: { context: Context }) {
   await upsertAccount(context, zeroAddress);
 
   // initialize the ENS root to be owned by the zeroAddress and not migrated
-  await context.db.insert(domains).values({
+  await context.db.insert(schema.domains).values({
     id: ROOT_NODE,
     ownerId: zeroAddress,
     createdAt: 0n,
@@ -23,7 +23,7 @@ export async function setupRootNode({ context }: { context: Context }) {
   });
 }
 
-function isDomainEmpty(domain: typeof domains.$inferSelect) {
+function isDomainEmpty(domain: typeof schema.domains.$inferSelect) {
   return (
     domain.resolverId === null && domain.ownerId === zeroAddress && domain.subdomainCount === 0
   );
@@ -32,13 +32,13 @@ function isDomainEmpty(domain: typeof domains.$inferSelect) {
 // a more accurate name for the following function
 // https://github.com/ensdomains/ens-subgraph/blob/master/src/ensRegistry.ts#L64
 async function recursivelyRemoveEmptyDomainFromParentSubdomainCount(context: Context, node: Hex) {
-  const domain = await context.db.find(domains, { id: node });
+  const domain = await context.db.find(schema.domains, { id: node });
   if (!domain) throw new Error(`Domain not found: ${node}`);
 
   if (isDomainEmpty(domain) && domain.parentId !== null) {
     // decrement parent's subdomain count
     await context.db
-      .update(domains, { id: domain.parentId })
+      .update(schema.domains, { id: domain.parentId })
       .set((row) => ({ subdomainCount: row.subdomainCount - 1 }));
 
     // recurse to parent
@@ -63,7 +63,7 @@ export async function handleTransfer({
 
   // ensure domain & update owner
   await context.db
-    .insert(domains)
+    .insert(schema.domains)
     .values([{ id: node, ownerId: owner, createdAt: event.block.timestamp }])
     .onConflictDoUpdate({ ownerId: owner });
 
@@ -95,13 +95,15 @@ export const handleNewOwner =
     await upsertAccount(context, owner);
 
     // note that we set isMigrated so that if this domain is being interacted with on the new registry, its migration status is set here
-    let domain = await context.db.find(domains, { id: subnode });
+    let domain = await context.db.find(schema.domains, { id: subnode });
     if (domain) {
       // if the domain already exists, this is just an update of the owner record (& isMigrated)
-      await context.db.update(domains, { id: domain.id }).set({ ownerId: owner, isMigrated });
+      await context.db
+        .update(schema.domains, { id: domain.id })
+        .set({ ownerId: owner, isMigrated });
     } else {
       // otherwise create the domain
-      domain = await context.db.insert(domains).values({
+      domain = await context.db.insert(schema.domains).values({
         id: subnode,
         ownerId: owner,
         parentId: node,
@@ -111,20 +113,20 @@ export const handleNewOwner =
 
       // and increment parent subdomainCount
       await context.db
-        .update(domains, { id: node })
+        .update(schema.domains, { id: node })
         .set((row) => ({ subdomainCount: row.subdomainCount + 1 }));
     }
 
     // if the domain doesn't yet have a name, construct it here
     if (!domain.name) {
-      const parent = await context.db.find(domains, { id: node });
+      const parent = await context.db.find(schema.domains, { id: node });
 
       // TODO: implement sync rainbow table lookups
       // https://github.com/ensdomains/ens-subgraph/blob/master/src/ensRegistry.ts#L111
       const labelName = encodeLabelhash(label);
       const name = parent?.name ? `${labelName}.${parent.name}` : labelName;
 
-      await context.db.update(domains, { id: domain.id }).set({ name, labelName });
+      await context.db.update(schema.domains, { id: domain.id }).set({ name, labelName });
     }
 
     // garbage collect newly 'empty' domain iff necessary
@@ -147,7 +149,7 @@ export async function handleNewTTL({
   // TODO: handle the edge case in which the domain no longer exists?
   // https://github.com/ensdomains/ens-subgraph/blob/master/src/ensRegistry.ts#L215
   // NOTE: i'm not sure this needs to be here, as domains are never deleted (??)
-  await context.db.update(domains, { id: node }).set({ ttl });
+  await context.db.update(schema.domains, { id: node }).set({ ttl });
 
   // TODO: log DomainEvent
 }
@@ -166,7 +168,7 @@ export async function handleNewResolver({
   // if zeroing out a domain's resolver, remove the reference instead of tracking a zeroAddress Resolver
   // NOTE: old resolver resources are kept for event logs
   if (event.args.resolver === zeroAddress) {
-    await context.db.update(domains, { id: node }).set({ resolverId: null });
+    await context.db.update(schema.domains, { id: node }).set({ resolverId: null });
 
     // garbage collect newly 'empty' domain iff necessary
     await recursivelyRemoveEmptyDomainFromParentSubdomainCount(context, node);
@@ -175,7 +177,7 @@ export async function handleNewResolver({
     const resolverId = makeResolverId(node, resolverAddress);
 
     const resolver = await context.db
-      .insert(resolvers)
+      .insert(schema.resolvers)
       .values({
         id: resolverId,
         domainId: event.args.node,
@@ -185,7 +187,7 @@ export async function handleNewResolver({
 
     // update the domain to point to it, and denormalize the eth addr
     await context.db
-      .update(domains, { id: node })
+      .update(schema.domains, { id: node })
       .set({ resolverId, resolvedAddress: resolver?.addrId });
   }
 

--- a/src/handlers/Registry.ts
+++ b/src/handlers/Registry.ts
@@ -15,7 +15,7 @@ export async function setupRootNode({ context }: { context: Context }) {
   await upsertAccount(context, zeroAddress);
 
   // initialize the ENS root to be owned by the zeroAddress and not migrated
-  await context.db.insert(schema.domains).values({
+  await context.db.insert(schema.domain).values({
     id: ROOT_NODE,
     ownerId: zeroAddress,
     createdAt: 0n,
@@ -23,7 +23,7 @@ export async function setupRootNode({ context }: { context: Context }) {
   });
 }
 
-function isDomainEmpty(domain: typeof schema.domains.$inferSelect) {
+function isDomainEmpty(domain: typeof schema.domain.$inferSelect) {
   return (
     domain.resolverId === null && domain.ownerId === zeroAddress && domain.subdomainCount === 0
   );
@@ -32,13 +32,13 @@ function isDomainEmpty(domain: typeof schema.domains.$inferSelect) {
 // a more accurate name for the following function
 // https://github.com/ensdomains/ens-subgraph/blob/master/src/ensRegistry.ts#L64
 async function recursivelyRemoveEmptyDomainFromParentSubdomainCount(context: Context, node: Hex) {
-  const domain = await context.db.find(schema.domains, { id: node });
+  const domain = await context.db.find(schema.domain, { id: node });
   if (!domain) throw new Error(`Domain not found: ${node}`);
 
   if (isDomainEmpty(domain) && domain.parentId !== null) {
     // decrement parent's subdomain count
     await context.db
-      .update(schema.domains, { id: domain.parentId })
+      .update(schema.domain, { id: domain.parentId })
       .set((row) => ({ subdomainCount: row.subdomainCount - 1 }));
 
     // recurse to parent
@@ -63,7 +63,7 @@ export async function handleTransfer({
 
   // ensure domain & update owner
   await context.db
-    .insert(schema.domains)
+    .insert(schema.domain)
     .values([{ id: node, ownerId: owner, createdAt: event.block.timestamp }])
     .onConflictDoUpdate({ ownerId: owner });
 
@@ -95,15 +95,13 @@ export const handleNewOwner =
     await upsertAccount(context, owner);
 
     // note that we set isMigrated so that if this domain is being interacted with on the new registry, its migration status is set here
-    let domain = await context.db.find(schema.domains, { id: subnode });
+    let domain = await context.db.find(schema.domain, { id: subnode });
     if (domain) {
       // if the domain already exists, this is just an update of the owner record (& isMigrated)
-      await context.db
-        .update(schema.domains, { id: domain.id })
-        .set({ ownerId: owner, isMigrated });
+      await context.db.update(schema.domain, { id: domain.id }).set({ ownerId: owner, isMigrated });
     } else {
       // otherwise create the domain
-      domain = await context.db.insert(schema.domains).values({
+      domain = await context.db.insert(schema.domain).values({
         id: subnode,
         ownerId: owner,
         parentId: node,
@@ -113,20 +111,20 @@ export const handleNewOwner =
 
       // and increment parent subdomainCount
       await context.db
-        .update(schema.domains, { id: node })
+        .update(schema.domain, { id: node })
         .set((row) => ({ subdomainCount: row.subdomainCount + 1 }));
     }
 
     // if the domain doesn't yet have a name, construct it here
     if (!domain.name) {
-      const parent = await context.db.find(schema.domains, { id: node });
+      const parent = await context.db.find(schema.domain, { id: node });
 
       // TODO: implement sync rainbow table lookups
       // https://github.com/ensdomains/ens-subgraph/blob/master/src/ensRegistry.ts#L111
       const labelName = encodeLabelhash(label);
       const name = parent?.name ? `${labelName}.${parent.name}` : labelName;
 
-      await context.db.update(schema.domains, { id: domain.id }).set({ name, labelName });
+      await context.db.update(schema.domain, { id: domain.id }).set({ name, labelName });
     }
 
     // garbage collect newly 'empty' domain iff necessary
@@ -149,7 +147,7 @@ export async function handleNewTTL({
   // TODO: handle the edge case in which the domain no longer exists?
   // https://github.com/ensdomains/ens-subgraph/blob/master/src/ensRegistry.ts#L215
   // NOTE: i'm not sure this needs to be here, as domains are never deleted (??)
-  await context.db.update(schema.domains, { id: node }).set({ ttl });
+  await context.db.update(schema.domain, { id: node }).set({ ttl });
 
   // TODO: log DomainEvent
 }
@@ -168,7 +166,7 @@ export async function handleNewResolver({
   // if zeroing out a domain's resolver, remove the reference instead of tracking a zeroAddress Resolver
   // NOTE: old resolver resources are kept for event logs
   if (event.args.resolver === zeroAddress) {
-    await context.db.update(schema.domains, { id: node }).set({ resolverId: null });
+    await context.db.update(schema.domain, { id: node }).set({ resolverId: null });
 
     // garbage collect newly 'empty' domain iff necessary
     await recursivelyRemoveEmptyDomainFromParentSubdomainCount(context, node);
@@ -177,7 +175,7 @@ export async function handleNewResolver({
     const resolverId = makeResolverId(node, resolverAddress);
 
     const resolver = await context.db
-      .insert(schema.resolvers)
+      .insert(schema.resolver)
       .values({
         id: resolverId,
         domainId: event.args.node,
@@ -187,7 +185,7 @@ export async function handleNewResolver({
 
     // update the domain to point to it, and denormalize the eth addr
     await context.db
-      .update(schema.domains, { id: node })
+      .update(schema.domain, { id: node })
       .set({ resolverId, resolvedAddress: resolver?.addrId });
   }
 

--- a/src/handlers/Resolver.ts
+++ b/src/handlers/Resolver.ts
@@ -1,5 +1,5 @@
 import { type Context } from "ponder:registry";
-import { domains, resolvers } from "ponder:schema";
+import schema from "ponder:schema";
 import { Log } from "ponder";
 import { Hex } from "viem";
 import { hasNullByte, uniq } from "../lib/helpers";
@@ -28,9 +28,9 @@ export async function handleAddrChanged({
   });
 
   // materialize the resolved add to the domain iff this resolver is active
-  const domain = await context.db.find(domains, { id: node });
+  const domain = await context.db.find(schema.domains, { id: node });
   if (domain?.resolverId === id) {
-    await context.db.update(domains, { id: node }).set({ resolvedAddress: address });
+    await context.db.update(schema.domains, { id: node }).set({ resolvedAddress: address });
   }
 
   // TODO: log ResolverEvent
@@ -58,7 +58,7 @@ export async function handleAddressChanged({
 
   // upsert the new coinType
   await context.db
-    .update(resolvers, { id })
+    .update(schema.resolvers, { id })
     .set({ coinTypes: uniq([...resolver.coinTypes, coinType]) });
 
   // TODO: log ResolverEvent
@@ -148,7 +148,7 @@ export async function handleTextChanged({
   });
 
   // upsert new key
-  await context.db.update(resolvers, { id }).set({ texts: uniq([...resolver.texts, key]) });
+  await context.db.update(schema.resolvers, { id }).set({ texts: uniq([...resolver.texts, key]) });
 
   // TODO: log ResolverEvent
 }
@@ -242,16 +242,16 @@ export async function handleVersionChanged({
   // a version change nulls out the resolver
   const { node } = event.args;
   const id = makeResolverId(node, event.log.address);
-  const domain = await context.db.find(domains, { id: node });
+  const domain = await context.db.find(schema.domains, { id: node });
   if (!domain) throw new Error("domain expected");
 
   // materialize the Domain's resolvedAddress field
   if (domain.resolverId === id) {
-    await context.db.update(domains, { id: node }).set({ resolvedAddress: null });
+    await context.db.update(schema.domains, { id: node }).set({ resolvedAddress: null });
   }
 
   // clear out the resolver's info
-  await context.db.update(resolvers, { id }).set({
+  await context.db.update(schema.resolvers, { id }).set({
     addrId: null,
     contentHash: null,
     coinTypes: [],

--- a/src/handlers/Resolver.ts
+++ b/src/handlers/Resolver.ts
@@ -28,9 +28,9 @@ export async function handleAddrChanged({
   });
 
   // materialize the resolved add to the domain iff this resolver is active
-  const domain = await context.db.find(schema.domains, { id: node });
+  const domain = await context.db.find(schema.domain, { id: node });
   if (domain?.resolverId === id) {
-    await context.db.update(schema.domains, { id: node }).set({ resolvedAddress: address });
+    await context.db.update(schema.domain, { id: node }).set({ resolvedAddress: address });
   }
 
   // TODO: log ResolverEvent
@@ -58,7 +58,7 @@ export async function handleAddressChanged({
 
   // upsert the new coinType
   await context.db
-    .update(schema.resolvers, { id })
+    .update(schema.resolver, { id })
     .set({ coinTypes: uniq([...resolver.coinTypes, coinType]) });
 
   // TODO: log ResolverEvent
@@ -148,7 +148,7 @@ export async function handleTextChanged({
   });
 
   // upsert new key
-  await context.db.update(schema.resolvers, { id }).set({ texts: uniq([...resolver.texts, key]) });
+  await context.db.update(schema.resolver, { id }).set({ texts: uniq([...resolver.texts, key]) });
 
   // TODO: log ResolverEvent
 }
@@ -242,16 +242,16 @@ export async function handleVersionChanged({
   // a version change nulls out the resolver
   const { node } = event.args;
   const id = makeResolverId(node, event.log.address);
-  const domain = await context.db.find(schema.domains, { id: node });
+  const domain = await context.db.find(schema.domain, { id: node });
   if (!domain) throw new Error("domain expected");
 
   // materialize the Domain's resolvedAddress field
   if (domain.resolverId === id) {
-    await context.db.update(schema.domains, { id: node }).set({ resolvedAddress: null });
+    await context.db.update(schema.domain, { id: node }).set({ resolvedAddress: null });
   }
 
   // clear out the resolver's info
-  await context.db.update(schema.resolvers, { id }).set({
+  await context.db.update(schema.resolver, { id }).set({
     addrId: null,
     contentHash: null,
     coinTypes: [],

--- a/src/lib/upserts.ts
+++ b/src/lib/upserts.ts
@@ -1,18 +1,21 @@
 import type { Context } from "ponder:registry";
-import { accounts, registrations, resolvers } from "ponder:schema";
+import schema from "ponder:schema";
 import type { Address } from "viem";
 
 export async function upsertAccount(context: Context, address: Address) {
-  return await context.db.insert(accounts).values({ id: address }).onConflictDoNothing();
+  return await context.db.insert(schema.accounts).values({ id: address }).onConflictDoNothing();
 }
 
-export async function upsertResolver(context: Context, values: typeof resolvers.$inferInsert) {
-  return await context.db.insert(resolvers).values(values).onConflictDoUpdate(values);
+export async function upsertResolver(
+  context: Context,
+  values: typeof schema.resolvers.$inferInsert,
+) {
+  return await context.db.insert(schema.resolvers).values(values).onConflictDoUpdate(values);
 }
 
 export async function upsertRegistration(
   context: Context,
-  values: typeof registrations.$inferInsert,
+  values: typeof schema.registrations.$inferInsert,
 ) {
-  return await context.db.insert(registrations).values(values).onConflictDoUpdate(values);
+  return await context.db.insert(schema.registrations).values(values).onConflictDoUpdate(values);
 }

--- a/src/lib/upserts.ts
+++ b/src/lib/upserts.ts
@@ -3,19 +3,19 @@ import schema from "ponder:schema";
 import type { Address } from "viem";
 
 export async function upsertAccount(context: Context, address: Address) {
-  return await context.db.insert(schema.accounts).values({ id: address }).onConflictDoNothing();
+  return await context.db.insert(schema.account).values({ id: address }).onConflictDoNothing();
 }
 
 export async function upsertResolver(
   context: Context,
-  values: typeof schema.resolvers.$inferInsert,
+  values: typeof schema.resolver.$inferInsert,
 ) {
-  return await context.db.insert(schema.resolvers).values(values).onConflictDoUpdate(values);
+  return await context.db.insert(schema.resolver).values(values).onConflictDoUpdate(values);
 }
 
 export async function upsertRegistration(
   context: Context,
-  values: typeof schema.registrations.$inferInsert,
+  values: typeof schema.registration.$inferInsert,
 ) {
-  return await context.db.insert(schema.registrations).values(values).onConflictDoUpdate(values);
+  return await context.db.insert(schema.registration).values(values).onConflictDoUpdate(values);
 }

--- a/src/plugins/base.eth/handlers/Registrar.ts
+++ b/src/plugins/base.eth/handlers/Registrar.ts
@@ -1,5 +1,5 @@
 import { ponder } from "ponder:registry";
-import { domains } from "ponder:schema";
+import schema from "ponder:schema";
 import { makeRegistrarHandlers } from "../../../handlers/Registrar";
 import { makeSubnodeNamehash, tokenIdToLabel } from "../../../lib/subname-helpers";
 import { upsertAccount } from "../../../lib/upserts";
@@ -31,7 +31,7 @@ export default function () {
     const node = makeSubnodeNamehash(ownedSubnameNode, label);
     await upsertAccount(context, owner);
     await context.db
-      .insert(domains)
+      .insert(schema.domains)
       .values({
         id: node,
         ownerId: owner,

--- a/src/plugins/base.eth/handlers/Registrar.ts
+++ b/src/plugins/base.eth/handlers/Registrar.ts
@@ -31,7 +31,7 @@ export default function () {
     const node = makeSubnodeNamehash(ownedSubnameNode, label);
     await upsertAccount(context, owner);
     await context.db
-      .insert(schema.domains)
+      .insert(schema.domain)
       .values({
         id: node,
         ownerId: owner,

--- a/src/plugins/eth/handlers/Registry.ts
+++ b/src/plugins/eth/handlers/Registry.ts
@@ -1,5 +1,5 @@
 import { type Context, ponder } from "ponder:registry";
-import { domains } from "ponder:schema";
+import schema from "ponder:schema";
 import { type Hex } from "viem";
 import {
   handleNewOwner,
@@ -13,7 +13,7 @@ import { pluginNamespace } from "../ponder.config";
 
 // a domain is migrated iff it exists and isMigrated is set to true, otherwise it is not
 async function isDomainMigrated(context: Context, node: Hex) {
-  const domain = await context.db.find(domains, { id: node });
+  const domain = await context.db.find(schema.domains, { id: node });
   return domain?.isMigrated ?? false;
 }
 

--- a/src/plugins/eth/handlers/Registry.ts
+++ b/src/plugins/eth/handlers/Registry.ts
@@ -13,7 +13,7 @@ import { pluginNamespace } from "../ponder.config";
 
 // a domain is migrated iff it exists and isMigrated is set to true, otherwise it is not
 async function isDomainMigrated(context: Context, node: Hex) {
-  const domain = await context.db.find(schema.domains, { id: node });
+  const domain = await context.db.find(schema.domain, { id: node });
   return domain?.isMigrated ?? false;
 }
 


### PR DESCRIPTION
- first commit moves the individual imports to a module import
  - from `import { domains } from "ponder:schema"` and `.insert(domains)`
  - to `import schema from "ponder:schema"` and `.insert(schema.domains)`
- second comment renames the tables so
  - from `.insert(schema.domains)`
  - to `.insert(schema.domain)`

this makes the autogenerated api correct